### PR TITLE
SystemUI: Allow setting custom rounded corner shapes

### DIFF
--- a/packages/SystemUI/res/drawable/rounded_bottom.xml
+++ b/packages/SystemUI/res/drawable/rounded_bottom.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (C) 2016 The Android Open Source Project
+
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="8dp"
+    android:height="8dp"
+    android:viewportWidth="8"
+    android:viewportHeight="8">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M8,0H0v8C0,3.6,3.6,0,8,0z" />
+
+</vector>

--- a/packages/SystemUI/res/drawable/rounded_top.xml
+++ b/packages/SystemUI/res/drawable/rounded_top.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (C) 2016 The Android Open Source Project
+
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="8dp"
+    android:height="8dp"
+    android:viewportWidth="8"
+    android:viewportHeight="8">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M8,0H0v8C0,3.6,3.6,0,8,0z" />
+
+</vector>

--- a/packages/SystemUI/res/values/cr_config.xml
+++ b/packages/SystemUI/res/values/cr_config.xml
@@ -39,4 +39,8 @@
 
     <!-- Allow devices override audio panel location to the left side -->
     <bool name="config_audioPanelOnLeftSide">false</bool>
+
+    <!-- Allow devices to use unordinary cutout overlays -->
+    <bool name="config_customCutout">false</bool>
+
 </resources>

--- a/packages/SystemUI/res/values/cr_dimens.xml
+++ b/packages/SystemUI/res/values/cr_dimens.xml
@@ -24,4 +24,10 @@
     <!-- screenrecord -->
     <dimen name="screenrecord_dot_size">48dp</dimen>
 
+    <!-- Custom cutout overlay view sizes -->
+    <dimen name="config_customCutoutTopWidth">0.0px</dimen>
+    <dimen name="config_customCutoutTopHeight">0.0px</dimen>
+    <dimen name="config_customCutoutBottomWidth">0.0px</dimen>
+    <dimen name="config_customCutoutBottomHeight">0.0px</dimen>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/ScreenDecorations.java
+++ b/packages/SystemUI/src/com/android/systemui/ScreenDecorations.java
@@ -37,6 +37,8 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.ColorStateList;
 import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;
@@ -129,6 +131,7 @@ public class ScreenDecorations extends SystemUI implements Tunable,
     private boolean mAssistHintBlocked = false;
     private boolean mIsReceivingNavBarColor = false;
     private boolean mInGesturalMode;
+    private boolean mCustomCutout;
 
     /**
      * Converts a set of {@link Rect}s into a {@link Region}
@@ -372,6 +375,7 @@ public class ScreenDecorations extends SystemUI implements Tunable,
     }
 
     private void setupDecorations() {
+        mCustomCutout = mContext.getResources().getBoolean(R.bool.config_customCutout);
         mOverlay = LayoutInflater.from(mContext)
                 .inflate(R.layout.rounded_corners, null);
         mCutoutTop = new DisplayCutoutView(mContext, true,
@@ -392,6 +396,7 @@ public class ScreenDecorations extends SystemUI implements Tunable,
         mBottomOverlay.setForceDarkAllowed(false);
 
         updateViews();
+        initRoundCornerViews();
 
         mWindowManager.addView(mOverlay, getWindowLayoutParams());
         mWindowManager.addView(mBottomOverlay, getBottomLayoutParams());
@@ -549,24 +554,24 @@ public class ScreenDecorations extends SystemUI implements Tunable,
 
         if (mRotation == RotationUtils.ROTATION_NONE) {
             updateView(topLeft, Gravity.TOP | Gravity.LEFT, 0);
-            updateView(topRight, Gravity.TOP | Gravity.RIGHT, 90);
-            updateView(bottomLeft, Gravity.BOTTOM | Gravity.LEFT, 270);
-            updateView(bottomRight, Gravity.BOTTOM | Gravity.RIGHT, 180);
+            updateView(topRight, Gravity.TOP | Gravity.RIGHT, mCustomCutout ? 0 : 90);
+            updateView(bottomLeft, Gravity.BOTTOM | Gravity.LEFT, mCustomCutout ? 0 : 270);
+            updateView(bottomRight, Gravity.BOTTOM | Gravity.RIGHT, mCustomCutout ? 0 : 180);
         } else if (mRotation == RotationUtils.ROTATION_LANDSCAPE) {
             updateView(topLeft, Gravity.TOP | Gravity.LEFT, 0);
-            updateView(topRight, Gravity.BOTTOM | Gravity.LEFT, 270);
-            updateView(bottomLeft, Gravity.TOP | Gravity.RIGHT, 90);
-            updateView(bottomRight, Gravity.BOTTOM | Gravity.RIGHT, 180);
+            updateView(topRight, Gravity.BOTTOM | Gravity.LEFT, mCustomCutout ? 180 : 270);
+            updateView(bottomLeft, Gravity.TOP | Gravity.RIGHT, mCustomCutout ? 180 : 90);
+            updateView(bottomRight, Gravity.BOTTOM | Gravity.RIGHT, mCustomCutout ? 0 : 180);
         } else if (mRotation == RotationUtils.ROTATION_UPSIDE_DOWN) {
             updateView(topLeft, Gravity.BOTTOM | Gravity.LEFT, 270);
-            updateView(topRight, Gravity.BOTTOM | Gravity.RIGHT, 180);
-            updateView(bottomLeft, Gravity.TOP | Gravity.LEFT, 0);
+            updateView(topRight, Gravity.BOTTOM | Gravity.RIGHT, mCustomCutout ? 270 : 180);
+            updateView(bottomLeft, Gravity.TOP | Gravity.LEFT, mCustomCutout ? 90 : 0);
             updateView(bottomRight, Gravity.TOP | Gravity.RIGHT, 90);
         } else if (mRotation == RotationUtils.ROTATION_SEASCAPE) {
             updateView(topLeft, Gravity.BOTTOM | Gravity.RIGHT, 180);
-            updateView(topRight, Gravity.TOP | Gravity.RIGHT, 90);
-            updateView(bottomLeft, Gravity.BOTTOM | Gravity.LEFT, 270);
-            updateView(bottomRight, Gravity.TOP | Gravity.LEFT, 0);
+            updateView(topRight, Gravity.TOP | Gravity.RIGHT, mCustomCutout ? 0 : 90);
+            updateView(bottomLeft, Gravity.BOTTOM | Gravity.LEFT, mCustomCutout ? 0 : 270);
+            updateView(bottomRight, Gravity.TOP | Gravity.LEFT, mCustomCutout ? 180 : 0);
         }
 
         updateAssistantHandleViews();
@@ -733,6 +738,8 @@ public class ScreenDecorations extends SystemUI implements Tunable,
     public void onTuningChanged(String key, String newValue) {
         mHandler.post(() -> {
             if (mOverlay == null) return;
+            // If custom cutout is used, initRoundCornerViews() will set the size
+            if (mCustomCutout) return;
             if (SIZE.equals(key)) {
                 int size = mRoundedDefault;
                 int sizeTop = mRoundedDefaultTop;
@@ -763,6 +770,13 @@ public class ScreenDecorations extends SystemUI implements Tunable,
         LayoutParams params = view.getLayoutParams();
         params.width = pixelSize;
         params.height = pixelSize;
+        view.setLayoutParams(params);
+    }
+
+    private void setSize(View view, int width, int height) {
+        LayoutParams params = view.getLayoutParams();
+        params.width = width;
+        params.height = height;
         view.setLayoutParams(params);
     }
 
@@ -1149,5 +1163,36 @@ public class ScreenDecorations extends SystemUI implements Tunable,
             }
             return true;
         }
+    }
+
+    private void initRoundCornerViews() {
+        if (!mCustomCutout) {
+            return;
+        }
+
+        Resources res = mContext.getResources();
+
+        int topWidth = res.getDimensionPixelSize(R.dimen.config_customCutoutTopWidth);
+        int topHeight = res.getDimensionPixelSize(R.dimen.config_customCutoutTopHeight);
+        int bottomWidth = res.getDimensionPixelSize(R.dimen.config_customCutoutBottomWidth);
+        int bottomHeight = res.getDimensionPixelSize(R.dimen.config_customCutoutBottomHeight);
+
+        ImageView topLeft = (ImageView) mOverlay.findViewById(R.id.left);
+        ImageView topRight = (ImageView) mOverlay.findViewById(R.id.right);
+        ImageView bottomLeft = (ImageView) mBottomOverlay.findViewById(R.id.left);
+        ImageView bottomRight = (ImageView) mBottomOverlay.findViewById(R.id.right);
+
+        topLeft.setImageResource(R.drawable.rounded_top);
+        topRight.setImageResource(R.drawable.rounded_top);
+        bottomLeft.setImageResource(R.drawable.rounded_bottom);
+        bottomRight.setImageResource(R.drawable.rounded_bottom);
+
+        setSize(topLeft, topWidth, topHeight);
+        setSize(topRight, topWidth, topHeight);
+        setSize(bottomLeft, bottomWidth, bottomHeight);
+        setSize(bottomRight, bottomWidth, bottomHeight);
+
+        topRight.setRotationY(180.0f);
+        bottomRight.setRotationY(180.0f);
     }
 }


### PR DESCRIPTION
Some devices do not have perfectly-circular corner and using
the existing method looks either weird or aliased.

Allow setting custom cutout shapes via vector xml.

Change-Id: I228ea98a8cfd986d05fcb6d272c8a3c5c1d1f4dc
Signed-off-by: Park Ju Hyung <qkrwngud825@gmail.com>
Signed-off-by: Anirudh Gupta <anirudhgupta109@gmail.com>